### PR TITLE
Update GRsync.py

### DIFF
--- a/GRsync.py
+++ b/GRsync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env python -u
 # -*- coding: utf-8 -*-
 
 import urllib.request as urllib2


### PR DESCRIPTION
Added /usr/bin/env shebang avoiding hardcoded python path.  Code as it was would not execute under homebrew installed python on OSX. This change should execute on all *nix/osx environments.